### PR TITLE
Add simple C++ WebAR viewer

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - name: Build C++ example
+        run: |
+          docker run --rm -v $PWD/cpp:/src emscripten/emsdk bash -c "cd /src && ./build.sh"
+          mkdir -p public/cpp
+          cp cpp/build/ar_viewer.html public/cpp/index.html
+          cp cpp/build/ar_viewer.js public/cpp/
+          cp cpp/build/ar_viewer.wasm public/cpp/
+      - name: Copy static files
+        run: |
+          mkdir -p public/models
+          cp index.html public/index.html
+          cp -r models/* public/models/
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./public
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# AR Viewer
+
+This repository provides a minimal Web AR viewer. The root `index.html` loads a GLB model with [three.js](https://threejs.org/). A C++ implementation using [threepp](https://github.com/markaren/threepp) lives in the `cpp` directory and can be compiled to WebAssembly with Emscripten.
+
+## GitHub Pages Deployment
+
+A GitHub Actions workflow in `.github/workflows/pages.yml` builds the C++ example and publishes the static files to GitHub Pages whenever the `main` branch is updated. After the workflow completes you can open the deployed site from the URL shown in the workflow logs.
+
+## Building the C++ Example Locally
+
+1. Install [Emscripten](https://emscripten.org/docs/getting_started/downloads.html).
+2. Run `cd cpp && ./build.sh` to compile the viewer.
+3. Serve the generated files in `cpp/build` with any static web server.
+
+The HTML viewer in the repository loads `models/model.glb` by default. You can replace this file or point the code to another path.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.10)
+project(ar_viewer)
+
+add_executable(ar_viewer main.cpp)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(threepp REQUIRED)
+
+# Emscripten options
+if(EMSCRIPTEN)
+    set(CMAKE_EXECUTABLE_SUFFIX ".html")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -sUSE_WEBGL2=1 -sUSE_ES6_IMPORT_META=0 -sALLOW_MEMORY_GROWTH=1")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -sFULL_ES2=1 -sUSE_WEBGL2=1 -sALLOW_MEMORY_GROWTH=1 -sUSE_PTHREADS=0")
+endif()
+

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,26 @@
+# C++ Web AR Viewer
+
+This folder contains an example of a very basic AR viewer written in C++ for the web. It uses the [threepp](https://github.com/markaren/threepp) library (a C++ port of three.js) and is intended to be compiled with Emscripten.
+
+The viewer loads a GLB model and allows setting a base point (target point). The model can be replaced by selecting another file through an HTML file input.
+
+## Building
+
+1. Install [Emscripten](https://emscripten.org/docs/getting_started/downloads.html).
+2. Install the `threepp` library. You can fetch it with CMake or add it manually.
+3. Build using CMake:
+
+```bash
+mkdir build
+cd build
+emcmake cmake ..
+cmake --build .
+```
+
+This should produce `index.html`, `main.js` and `main.wasm` that can be served with any static web server.
+
+## Running
+
+Serve the resulting files via a local web server. Open the page in a browser that supports WebXR to view the model in AR.
+
+The HTML page should contain an element with `id="fileInput"` for selecting models.

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+emcmake cmake -B build -S .
+cmake --build build

--- a/cpp/index.html
+++ b/cpp/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>AR Viewer (C++)</title>
+    <style>
+        body, html { margin: 0; padding: 0; overflow: hidden; }
+        #fileInput { position: absolute; top: 10px; left: 10px; z-index: 10; }
+    </style>
+</head>
+<body>
+    <input type="file" id="fileInput" accept="model/gltf-binary" />
+    <script src="ar_viewer.js"></script>
+</body>
+</html>

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -1,0 +1,59 @@
+#include <threepp/threepp.hpp>
+#include <threepp/utils/Utils.hpp>
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <iostream>
+
+using namespace threepp;
+
+Scene scene;
+std::shared_ptr<Object3D> model;
+Vector3 targetPoint(0, 0, 0);
+
+void loadModel(const std::string& path) {
+    GLTFLoader loader;
+    loader.load(path, [&](const GLTF& gltf) {
+        model = gltf.scene;
+        scene.add(model);
+        model->position.copy(targetPoint);
+    });
+}
+
+void setTargetPoint(float x, float y, float z) {
+    targetPoint.set(x, y, z);
+    if (model) {
+        model->position.copy(targetPoint);
+    }
+}
+
+void loop() {
+    requestAnimationFrame(loop);
+    Renderer::instance().render(scene, Camera::getActive());
+}
+
+int main() {
+    auto& renderer = WebGLRenderer::create();
+    scene = Scene::create();
+
+    auto camera = PerspectiveCamera::create(70, renderer.getAspect(), 0.01f, 1000);
+    camera->position.z = 5;
+    Camera::setActive(camera);
+
+    AmbientLight::create(0xffffff, 1)->addTo(scene);
+
+    // default model
+    loadModel("../models/model.glb");
+
+    EM_ASM(
+        document.getElementById('fileInput').onchange = function(evt) {
+            let file = evt.target.files[0];
+            if (file) {
+                let url = URL.createObjectURL(file);
+                Module.ccall('loadModel', null, ['string'], [url]);
+            }
+        };
+    );
+
+    loop();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `cpp` folder with a C++ WebAR example
- show how to build the example using Emscripten and threepp
- provide minimal HTML shell for running the wasm module

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: missing script `test`)*


------
https://chatgpt.com/codex/tasks/task_e_684a8e8a43f083289db51123cbaf5566